### PR TITLE
Adjust editor width for tab overflow

### DIFF
--- a/packages/ui/src/components/obeditor/Tab.tsx
+++ b/packages/ui/src/components/obeditor/Tab.tsx
@@ -142,7 +142,7 @@ const Tab: React.FC<TabProps> = ({
       <ContextMenuTrigger asChild>
         <div
           className={cn(
-            "group relative flex items-center min-w-0 h-8 flex-shrink-0",
+            "group relative flex items-center min-w-0 h-8",
             "border-r border-tab-border",
             tab.isActive 
               ? "bg-tab-active" 
@@ -150,9 +150,9 @@ const Tab: React.FC<TabProps> = ({
           )}
           style={maxWidth ? { 
             maxWidth: `${maxWidth}px`,
-            minWidth: '80px',  // 最小宽度确保可读性
-            width: `${Math.min(maxWidth, 200)}px`  // 固定宽度，不会随内容变化
-          } : { maxWidth: '200px', minWidth: '80px', width: '200px' }}
+            minWidth: '80px',
+            flex: `0 1 ${maxWidth}px` // 根据可用空间自动收缩，避免撑宽编辑器
+          } : { maxWidth: '200px', minWidth: '80px', flex: '0 1 200px' }}
         >
           {/* Tab content (drag handle area) */}
           <div 

--- a/packages/ui/src/components/panel.tsx
+++ b/packages/ui/src/components/panel.tsx
@@ -106,7 +106,7 @@ export const Panel: React.FC<PanelProps> = ({ className }) => {
       <Tabs value={currentPanel} className="h-full flex flex-col">
         {/* 标签页头部 */}
         <div className="flex items-center justify-between border-b bg-muted/50">
-          <TabsList className="flex w-auto items-center gap-1 h-9 bg-transparent overflow-x-auto">
+          <TabsList className="flex w-full min-w-0 items-center gap-1 h-9 bg-transparent overflow-x-auto">
             {panels.map((panel) => (
               <TabsTrigger
                 key={panel.id}


### PR DESCRIPTION
Allow editor tabs to shrink and truncate to prevent the editor from expanding when many tabs are open, mimicking Obsidian's behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf35330a-6b03-4d6e-ad7c-e0c2cccdc00f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf35330a-6b03-4d6e-ad7c-e0c2cccdc00f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

